### PR TITLE
Corrige l'arrêt du script build-data quand il n'y a pas de feature dans la fonction 'buildCarteSecteurFeatures'

### DIFF
--- a/lib/carte-secteur.js
+++ b/lib/carte-secteur.js
@@ -117,7 +117,11 @@ export async function buildCarteSecteurFeatures(codeCommune, rows, colleges) {
     .features
     .map(f => intersect(f, contourCommune, {properties: f.properties}))
     .map(f => {
-      f.properties = colleges[f.properties.codeRNE] || f.properties
-      return f
+      if (f?.properties) {
+        f.properties = colleges[f.properties.codeRNE] || f.properties
+        return f
+      }
+
+      return null
     })
 }


### PR DESCRIPTION
Dans `buildCarteSecteurFeatures` lorsqu'il n'y a pas de caractéristique, le script se termine avec une erreur.
Ajout de l'instruction `if` pour éviter l'erreur.